### PR TITLE
Create can_monitor_coryjlibrary

### DIFF
--- a/can_monitor_coryjlibrary
+++ b/can_monitor_coryjlibrary
@@ -1,0 +1,57 @@
+// CAN Receive Example
+//
+
+#include <mcp_can.h>
+#include <SPI.h>
+
+long unsigned int rxId;
+unsigned char len = 0;
+unsigned char rxBuf[8];
+char msgString[128];                        // Array to store serial string
+
+#define CAN0_INT 2                              // Set INT to pin 2
+MCP_CAN CAN0(10);                               // Set CS to pin 10
+
+
+void setup()
+{
+  Serial.begin(115200);
+
+  // Initialize MCP2515 running at 16MHz with a baudrate of 500kb/s and the masks and filters disabled.
+  if (CAN0.begin(MCP_ANY, CAN_33K3BPS, MCP_8MHZ) == CAN_OK) {
+
+
+    CAN0.setMode(MCP_NORMAL);                     // Set operation mode to normal so the MCP2515 sends acks to received data.
+
+    pinMode(CAN0_INT, INPUT);                            // Configuring pin for /INT input
+
+
+  }
+}
+
+void loop()
+{
+  if (!digitalRead(CAN0_INT))                        // If CAN0_INT pin is low, read receive buffer
+  {
+    CAN0.readMsgBuf(&rxId, &len, rxBuf);      // Read data: len = data length, buf = data byte(s)
+
+    Serial.print("FRAME:ID=");
+    Serial.print(rxId);
+    Serial.print(":LEN=");
+    Serial.print(len);
+
+
+    char msgString[3];
+    for (byte i = 0; i < len; i++) {
+      Serial.print(":");
+      snprintf(msgString, 3, "%02X", rxBuf[i]);
+      Serial.print(msgString);
+    }
+
+
+    Serial.println();
+  }
+}
+/*********************************************************************************************************
+  END FILE
+*********************************************************************************************************/


### PR DESCRIPTION
I modified this example from the coryjfowler library to work with your python script. 

This sketch can be modified to work with many different can bus baud rates along with both 8mhz/16mhz crystals. These are commonly found on the arduino mcp2515 daughter boards.  Refer to https://github.com/coryjfowler/MCP_CAN_lib for more info.